### PR TITLE
Update serviceTester

### DIFF
--- a/serviceTester
+++ b/serviceTester
@@ -57,11 +57,11 @@ chrome.webNavigation.onCompleted.addListener(details => {
 
     //then we need another alarm to turn the ruleset back off
     let reactivationTime = {
-        delayInMinutes: 60 * 12 //sets alarm for 12 hours from activation
+        delayInMinutes: 3 //sets alarm for 3 mins from activation
     };
     chrome.alarms.create(name = 'active ruleset timer', reactivationTime);
     //timer to deactivate the ruleset
-    console.log('deactivation alarm set for 1 minute from now');
+    console.log('deactivation alarm set for 3 mins from now');
 }, {
     url: [{ hostContains: '.reddit' },]
 });
@@ -70,8 +70,9 @@ chrome.webNavigation.onCompleted.addListener(details => {
 //now we have an active alarm that will go off 1 minute from now
 //so we need a listener to react to that alarm
 chrome.alarms.onAlarm.addListener(function (alarm) {
+    console.log(alarm.name);
     //we want to make sure we're getting the deactivate alarm and not the kick you out of the tab alarm
-    if (alarm.name = 'active ruleset timer') {
+    if (alarm.name === 'active ruleset timer') {
         //with the alarm triggered then we want to deactivate the ruleset again
         console.log('deactivating blocker');
         //instead of just a console log maybe we give a notification here
@@ -80,12 +81,29 @@ chrome.alarms.onAlarm.addListener(function (alarm) {
     };
 
     //here we can do the check for the boot out of tab alarm in the same function
-    if (alarm.name = 'too much time on tab') {
-
-        //highlight tab if it's not active
-        //notify that tab is being closed
-        //close out of tab
+    if (alarm.name === 'too much time on tab') {
+        //on this alarm activating we want to query whether we have any open tabs of the problem website
+        let blockedUrl = { url: '*://*.reddit.com/*' }; //query url prop takes string or array of string 
+        return chrome.tabs.query(blockedUrl) //this returns a promise with all the problem urls
+            .then((tabs) => {
+                console.log(tabs, 'made it into the promise then', 'tabs with the blocked url will now be closed.');
+                if (!tabs.length) return; //exit if we don't have any tabs found from the query
+                let map = tabs.map(t => t.id); // this creates a list of ids
+                console.log('made it past the if statement', 'here are a list of your tab ids', map);
+                chrome.tabs.remove(map); //close the tabs found
+                console.log('tabs from map successfully closed');
+            });
     };
+    //right now this function has an error removing the tabs:
+    //it may also be causing 
+    /*
+    Error in event handler: 
+    TypeError: Error in invocation of 
+        tabs.remove([integer|array] 
+            tabIds, optional function callback): 
+            
+            No matching signature.
+    */
 });
 
 //here are our two functions to turn on a ruleset or turn off a ruleset


### PR DESCRIPTION
figured out how to use cascading promises with .then.
used an alarm following access to the blocked site to trigger an amount of time later (here it's 1 min)
that amount of time later i used tabs.query to see how many offending tabs are open.
    that list of tabs is then mapped to create a list of tab IDs, which are closed.

also fixed an issue where alarms were colliding - instead of using comparative === i was using declarative = in my if statements to check the alarm name.

with that, now the blocker successfully closes out offending tabs and toggles itself back on at given times.

next step is to make user notifications rather than just console logs.