### PR TITLE
Update serviceWorker.js

### DIFF
--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -321,3 +321,20 @@ async function refreshCache() {
         }
     });
 };
+
+//ok we need a listener for when the machine goes back to being active to refresh our listeners
+chrome.idle.onStateChanged.addListener(function (idleState) {
+    console.log(idleState);
+    //now we need to refresh our listeners? 
+    //first get a list of our dynamic ids by refreshing our cache and pulling it from siteCache
+    refreshCache();
+    let tempArr = siteCache[dynamicIds];
+    //then we need to wipe out all our stored values so that we don't duplicate them
+    for (let i = 1; i < tempArr.length; i++) {
+        userRemoveSite(tempArr[i]);
+    };
+    //after wiping out our settings now we rebuild them from scratch to get the listeners back online
+    for (let i = 1; i < tempArr.length; i++) {
+        userInputSite(tempArr[i]);
+    };
+});


### PR DESCRIPTION
Two thoughts on how to maintain the listeners so that they are active whenever the user needs them - 
Either put them before every chance that the user could be navigating to a website, meaning that before oncompleted you'd have to put code onnavigated to add the listeners.
Seems like a lot.
This option is to refresh the listeners every time the state of the machine changes. On idle and on activate the whole cache of websites will be deleted and readded so that the listeners are fresh. 
Hopefully this works. It hasn't broken the code, but about to go through testing.