### PR TITLE
Update optionsPage.js

### DIFF
--- a/optionsPage.js
+++ b/optionsPage.js
@@ -157,6 +157,15 @@ function populateSettings() {
             }
             if (counter > 1) document.getElementById('user settings p').innerHTML = update;
             else document.getElementById('user settings p').innerHTML = 'You have no restricted websites.';
+
+            //then after the url settings are populated I want this to populate our timer settings too
+            let allowT = x.syncCache.closeTabs.delayInMinutes;
+            let deacT = x.syncCache.deactivate.delayInMinutes;
+            let blockT = deacT - allowT;
+            document.getElementById('allowRange').value = allowT;
+            document.getElementById('allowNum').value = allowT;
+            document.getElementById('blockRange').value = blockT;
+            document.getElementById('blockNum').value = blockT;
         }
     })
 };


### PR DESCRIPTION
well while we're doing a big 1.1 update I wanted to add a feature for better user visibility.
Before the timer slider was just stuck on the default setting of 1h, 23hrs. But now I've injected some logic into the populateSettings command so that every time it pulls the stored links, it'll also pull the stored time settings and set the sliders to that value instead of the default.
It's a nice little upgrade.