### PR TITLE
Update serviceWorker.js

### DIFF
--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -254,7 +254,11 @@ async function userRemoveSite(urlString) {
             console.log(`${urlString} not found in dynamicIds, could not be deleted.`)
             return;
         };
-        //now we have to check if we have too many sites in our cache- I don't want to overload the chrome ruleset maximum
+        //check if the userinput is null
+        if (urlString === null) {
+            console.log(`cannot delete null, but that's okay. :) `)
+            return;
+        };
 
         //first remove the site listener
         //our listener function's name is saved in our site cache


### PR DESCRIPTION
couldn't do it on the optionshtml side for some reason, wanted to stop the p block container from sending a null deletion
but added some validation in the serviceworker userRemoveSite command so that if null was ever passed into it as the url (like what was happening with the p block click) it doesn't geek out.

also removed an unnecessary line of comment